### PR TITLE
add django-rest-framework; add initial API for /applications endpoint

### DIFF
--- a/infrasee/infrasee/settings.py
+++ b/infrasee/infrasee/settings.py
@@ -32,6 +32,7 @@ ALLOWED_HOSTS = []
 
 INSTALLED_APPS = [
     'infrasee_core.apps.InfraseeCoreConfig',
+    'rest_framework',
     'django.contrib.admin',
     'django.contrib.auth',
     'django.contrib.contenttypes',
@@ -39,6 +40,10 @@ INSTALLED_APPS = [
     'django.contrib.messages',
     'django.contrib.staticfiles',
 ]
+
+REST_FRAMEWORK = {
+    'PAGE_SIZE': 50
+}
 
 MIDDLEWARE_CLASSES = [
     'django.middleware.security.SecurityMiddleware',

--- a/infrasee/infrasee_core/serializers.py
+++ b/infrasee/infrasee_core/serializers.py
@@ -1,0 +1,9 @@
+from rest_framework import serializers
+
+from .models import Application
+
+
+class ApplicationSerializer(serializers.HyperlinkedModelSerializer):
+    class Meta:
+        model = Application
+        fields = ('name', 'description')

--- a/infrasee/infrasee_core/urls.py
+++ b/infrasee/infrasee_core/urls.py
@@ -1,10 +1,15 @@
-from django.conf.urls import url
+from django.conf.urls import url, include
+from rest_framework import routers
 
 from . import views
+
+router = routers.DefaultRouter()
+router.register(r'applications', views.ApplicationViewSet)
 
 urlpatterns = [
     url(r'^$', views.IndexView.as_view(), name='index'),
     url(r'^version$', views.VersionView.as_view(), name='version'),
     url(r'^port$', views.PortView.as_view(), name='port'),
     url(r'^port/(?P<pk>[0-9]+)/$', views.PortDetailView.as_view(), name='port_details'),
+    url(r'^api/', include(router.urls))
 ]

--- a/infrasee/infrasee_core/views.py
+++ b/infrasee/infrasee_core/views.py
@@ -1,8 +1,11 @@
 from django.core import serializers
 from django.http import HttpResponse
 from django.views.generic import View
+from rest_framework import viewsets
 
 from .models import Port
+from .models import Application
+from .serializers import ApplicationSerializer
 
 
 class IndexView(View):
@@ -41,3 +44,11 @@ class PortDetailView(View):
     def post(self, request, pk):
         did_some_stuff = "stuff done"
         return HttpResponse(did_some_stuff)
+
+
+class ApplicationViewSet(viewsets.ModelViewSet):
+    """
+    API endpoint that allows applications to be viewed or edited.
+    """
+    queryset = Application.objects.all()
+    serializer_class = ApplicationSerializer

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+Django==1.9.2
+djangorestframework==3.3.2


### PR DESCRIPTION
Added the django-rest-framework to simplify defining REST API endpoints. It simplifies the serialization of models to json as well as combines Views into ViewSets which simplifies the handling of the various GET, POST, PUT, DELETE methods needed.
http://www.django-rest-framework.org/tutorial/quickstart/

Also introduced the requirements.txt which is used by pip for determining project dependencies. This can be created/updated by running `pip freeze > requirements.txt`. 
The dependencies for a project can be installed by running `pip install -r requirements.txt`.

Once this is merged in, the following URLs can be used to access the /applications endpoint.

http://host:8000/core/api/applications - references list of applications
/core/api/applications/{id} - references a single application
