### PR TITLE
Update .gitignore to exclude .DS_Store

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 venv/
 *.pyc
 *.sqlite3
+.DS_Store


### PR DESCRIPTION
Very minor, but stops git from thinking it needs to add .DS_Store files created by Finder on Mac.
